### PR TITLE
add void method call mutator (from gregor) to sbr group

### DIFF
--- a/cas9-engine/src/test/java/org/pitest/mutationtest/engine/cas9/config/Cas9EngineFactoryTest.java
+++ b/cas9-engine/src/test/java/org/pitest/mutationtest/engine/cas9/config/Cas9EngineFactoryTest.java
@@ -78,10 +78,12 @@ class Cas9EngineFactoryTest {
         nCopies(aor().size(), "AOR"), // double y = a / x;
         nCopies(uoi().size(), "UOI"), // skipIt(++x, y)
         nCopies(uoi().size(), "UOI"), // skipIt(x, ++y)
+        singleton("Voi"), // remove: skipIt(x, y)
         nCopies(uoi().size(), "UOI"), // if (++a < b)
         nCopies(uoi().size(), "UOI"), // if (a < ++b)
         nCopies(ror().size(), "ROR"), // if (a <= b)
-        nCopies(uoi().size(), "UOI")) // System.out.println("a: " + a++);
+        nCopies(uoi().size(), "UOI"), // System.out.println("a: " + a++);
+        singleton("Voi"))  // System.out.println("a: " + a++);
         .flatMap(Collection::stream)
         .toArray(String[]::new);
 

--- a/cas9-mutators/src/main/java/org/pitest/mutationtest/engine/cas9/mutators/Cas9Mutators.java
+++ b/cas9-mutators/src/main/java/org/pitest/mutationtest/engine/cas9/mutators/Cas9Mutators.java
@@ -1,10 +1,9 @@
 package org.pitest.mutationtest.engine.cas9.mutators;
 
-import static java.util.Collections.singleton;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.stream.Collectors.toSet;
 import static org.pitest.mutationtest.engine.cas9.mutators.lcr.LCRMutator.lcr;
-import static org.pitest.mutationtest.engine.cas9.mutators.sbr.SBRMutator.SBR_MUTATOR;
+import static org.pitest.mutationtest.engine.cas9.mutators.sbr.SBRMutator.sbr;
 import static org.pitest.mutationtest.engine.gregor.config.Mutator.aor;
 import static org.pitest.mutationtest.engine.gregor.config.Mutator.ror;
 import static org.pitest.mutationtest.engine.gregor.config.Mutator.uoi;
@@ -47,7 +46,7 @@ public class Cas9Mutators {
     mutatorByName.put("LCR", lcr());
     mutatorByName.put("UOI", uoi());
     mutatorByName.put("ROR", ror());
-    mutatorByName.put("SBR", singleton(SBR_MUTATOR));
+    mutatorByName.put("SBR", sbr());
     mutatorByName.put("AOR", aor());
     return unmodifiableMap(mutatorByName);
   }

--- a/cas9-mutators/src/main/java/org/pitest/mutationtest/engine/cas9/mutators/sbr/SBRMutator.java
+++ b/cas9-mutators/src/main/java/org/pitest/mutationtest/engine/cas9/mutators/sbr/SBRMutator.java
@@ -1,15 +1,24 @@
 package org.pitest.mutationtest.engine.cas9.mutators.sbr;
 
+import static java.util.Arrays.asList;
+import static org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator.VOID_METHOD_CALL_MUTATOR;
+
+import java.util.Collection;
 import org.pitest.mutationtest.engine.cas9.AstNodeTracker;
 import org.pitest.mutationtest.engine.cas9.AstSupportMutatorFactory;
 import org.pitest.mutationtest.engine.cas9.MethodAstInfo;
 import org.pitest.mutationtest.engine.gregor.MethodInfo;
+import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory;
 import org.pitest.mutationtest.engine.gregor.MutationContext;
 import org.pitest.reloc.asm.MethodVisitor;
 
 public enum SBRMutator implements AstSupportMutatorFactory {
 
   SBR_MUTATOR;
+
+  public static Collection<MethodMutatorFactory> sbr() {
+    return asList(VOID_METHOD_CALL_MUTATOR, SBR_MUTATOR);
+  }
 
   @Override
   public MethodVisitor create(MutationContext context, AstNodeTracker astTracker, MethodAstInfo astInfo,


### PR DESCRIPTION
The CAS9 SBR only removes block statements (like `if`, `for`, etc.). The removal of individual lines is already implemented by gregor in `org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator`.